### PR TITLE
Enabled Strict types and improved type hinting

### DIFF
--- a/src/Data/LinkHeaders.php
+++ b/src/Data/LinkHeaders.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace JustBetter\Http3EarlyHints\Data;
 
@@ -80,14 +82,14 @@ class LinkHeaders
             foreach ($parts as $part) {
                 preg_match('/(?<key>[^=]+)(?:="?(?<value>.*)"?)?/', trim($part), $matches);
                 $key = $matches['key'];
-                $value = $matches['value'] ?? '1';
+                $value = $matches['value'] ?? null;
 
                 if ($key === 'rel') {
                     $rel = $value;
 
                     continue;
                 }
-                $attributes[$key] = $value;
+                $attributes[$key] = $value ?? true;
             }
 
             $this->addLink($uri, $rel, $attributes);
@@ -102,8 +104,8 @@ class LinkHeaders
 
         foreach ($this->getLinkProvider()->getLinks() as $link) {
             /** @var Link $link */
-            $hash = md5($link->getHref(), true); // Previous the second parameter was: serialize($link->getRels()) which gives a string, where the second parameter excepts a boolean.
-            if (!in_array($hash, $handledHashes, true)) {
+            $hash = md5($link->getHref().serialize($link->getRels()));
+            if (! in_array($hash, $handledHashes, true)) {
                 $handledHashes[] = $hash;
 
                 continue;
@@ -118,7 +120,7 @@ class LinkHeaders
     public function __toString(): string
     {
         return trim(collect($this->getLinkProvider()->getLinks())
-            ->map([self::class, 'linkToString'])
+            ->map([static::class, 'linkToString'])
             ->filter()
             ->implode(','));
     }
@@ -140,7 +142,7 @@ class LinkHeaders
                 continue;
             }
 
-            if (!\is_bool($value)) {
+            if (! \is_bool($value)) {
                 $attributes[] = sprintf('%s="%s"', $key, $value);
 
                 continue;

--- a/src/Events/GenerateEarlyHints.php
+++ b/src/Events/GenerateEarlyHints.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace JustBetter\Http3EarlyHints\Events;
 

--- a/src/Events/GenerateEarlyHints.php
+++ b/src/Events/GenerateEarlyHints.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace JustBetter\Http3EarlyHints\Events;
 

--- a/src/Listeners/AddDefaultHeaders.php
+++ b/src/Listeners/AddDefaultHeaders.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace JustBetter\Http3EarlyHints\Listeners;
 
@@ -7,14 +7,14 @@ use JustBetter\Http3EarlyHints\Events\GenerateEarlyHints;
 
 class AddDefaultHeaders
 {
-    public function handle(GenerateEarlyHints $event)
+    public function handle(GenerateEarlyHints $event): void
     {
         foreach (config('http3earlyhints.default_headers', []) as $header) {
             $event->linkHeaders->addFromString($header);
         }
     }
 
-    public static function register()
+    public static function register(): void
     {
         Event::listen(GenerateEarlyHints::class, static::class);
     }

--- a/src/Listeners/AddDefaultHeaders.php
+++ b/src/Listeners/AddDefaultHeaders.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace JustBetter\Http3EarlyHints\Listeners;
 

--- a/src/Listeners/AddFromBody.php
+++ b/src/Listeners/AddFromBody.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace JustBetter\Http3EarlyHints\Listeners;
 

--- a/src/Listeners/AddFromBody.php
+++ b/src/Listeners/AddFromBody.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace JustBetter\Http3EarlyHints\Listeners;
 

--- a/src/Middleware/AddHttp3EarlyHints.php
+++ b/src/Middleware/AddHttp3EarlyHints.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace JustBetter\Http3EarlyHints\Middleware;
 
@@ -28,7 +30,7 @@ class AddHttp3EarlyHints
             $request->format() !== 'html'
             || (
                 str_contains($lastPath, '.')
-                && !in_array(Str::afterLast($lastPath, '.'), config('http3earlyhints.extensions', ['', 'php', 'html']), true)
+                && ! in_array(Str::afterLast($lastPath, '.'), config('http3earlyhints.extensions', ['', 'php', 'html']), true)
             )
         ) {
             $this->skipCurrentRequest = true;
@@ -91,9 +93,9 @@ class AddHttp3EarlyHints
     {
         if (
             $this->skipCurrentRequest
-            || !$response instanceof Response
+            || ! $response instanceof Response
             || $response->isRedirection()
-            || !$response->isSuccessful()
+            || ! $response->isSuccessful()
         ) {
             return null;
         }
@@ -115,7 +117,7 @@ class AddHttp3EarlyHints
 
         $this->linkHeaders->makeUnique();
 
-        $sizeLimit = $sizeLimit ?? max(1, (int)config('http3earlyhints.size_limit', 32 * 1024));
+        $sizeLimit = $sizeLimit ?? max(1, (int) config('http3earlyhints.size_limit', 32 * 1024));
         $headersText = $this->linkHeaders->__toString();
 
         while (strlen($headersText) > $sizeLimit) {
@@ -132,7 +134,7 @@ class AddHttp3EarlyHints
     private function addLinkHeaders(SymfonyResponse $response, LinkHeaders $linkHeaders): void
     {
         $link = $linkHeaders->__toString();
-        if (!$link || !$response instanceof Response) {
+        if (! $link || ! $response instanceof Response) {
             return;
         }
 

--- a/src/Middleware/AddHttp3EarlyHints.php
+++ b/src/Middleware/AddHttp3EarlyHints.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace JustBetter\Http3EarlyHints\Middleware;
 
@@ -26,7 +26,10 @@ class AddHttp3EarlyHints
         $lastPath = Str::afterLast($request->path(), '/');
         if (
             $request->format() !== 'html'
-            || (str_contains($lastPath, '.') && ! in_array(Str::afterLast($lastPath, '.'), config('http3earlyhints.extensions', ['', 'php', 'html'])))
+            || (
+                str_contains($lastPath, '.')
+                && !in_array(Str::afterLast($lastPath, '.'), config('http3earlyhints.extensions', ['', 'php', 'html']), true)
+            )
         ) {
             $this->skipCurrentRequest = true;
 
@@ -84,15 +87,15 @@ class AddHttp3EarlyHints
         $this->handleGeneratingLinkHeaders($request, $response);
     }
 
-    public function handleGeneratingLinkHeaders(Request $request, SymfonyResponse $response)
+    public function handleGeneratingLinkHeaders(Request $request, SymfonyResponse $response): ?LinkHeaders
     {
         if (
-            ! $response instanceof Response
+            $this->skipCurrentRequest
+            || !$response instanceof Response
             || $response->isRedirection()
-            || ! $response->isSuccessful()
-            || $this->skipCurrentRequest
+            || !$response->isSuccessful()
         ) {
-            return;
+            return null;
         }
         $linkHeaders = $this->generateLinkHeaders($request, $response, $this->sizeLimit);
 
@@ -112,7 +115,7 @@ class AddHttp3EarlyHints
 
         $this->linkHeaders->makeUnique();
 
-        $sizeLimit = $sizeLimit ?? max(1, intval(config('http3earlyhints.size_limit', 32 * 1024)));
+        $sizeLimit = $sizeLimit ?? max(1, (int)config('http3earlyhints.size_limit', 32 * 1024));
         $headersText = $this->linkHeaders->__toString();
 
         while (strlen($headersText) > $sizeLimit) {
@@ -126,18 +129,17 @@ class AddHttp3EarlyHints
     /**
      * Add Link Header
      */
-    private function addLinkHeaders(SymfonyResponse $response, LinkHeaders $linkHeaders): SymfonyResponse
+    private function addLinkHeaders(SymfonyResponse $response, LinkHeaders $linkHeaders): void
     {
         $link = $linkHeaders->__toString();
-        if (! $link || ! $response instanceof Response) {
-            return $response;
+        if (!$link || !$response instanceof Response) {
+            return;
         }
+
         if ($response->headers->get('Link')) {
             $link = $response->headers->get('Link').','.$link;
         }
 
         $response->header('Link', $link);
-
-        return $response;
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace JustBetter\Http3EarlyHints;
 
@@ -10,8 +12,6 @@ class ServiceProvider extends LaravelServiceProvider
 {
     /**
      * Perform post-registration booting of services.
-     *
-     * @return void
      */
     public function boot(): void
     {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace JustBetter\Http3EarlyHints;
 
@@ -13,7 +13,7 @@ class ServiceProvider extends LaravelServiceProvider
      *
      * @return void
      */
-    public function boot()
+    public function boot(): void
     {
         $this->mergeConfigFrom(__DIR__.'/config.php', 'http3earlyhints');
 

--- a/src/config.php
+++ b/src/config.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 return [
     /**

--- a/src/config.php
+++ b/src/config.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 return [
     /**

--- a/tests/AddHttp3EarlyHintsTest.php
+++ b/tests/AddHttp3EarlyHintsTest.php
@@ -206,7 +206,7 @@ class AddHttp3EarlyHintsTest extends TestCase
 
     protected function getNext(string $pageName): Closure
     {
-        return static fn ($request) => new Response(
+        return fn ($request) => new Response(
             content: $this->getHtml($pageName),
         );
     }

--- a/tests/AddHttp3EarlyHintsTest.php
+++ b/tests/AddHttp3EarlyHintsTest.php
@@ -1,8 +1,12 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace JustBetter\Http3EarlyHints\Tests;
 
+use Closure;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Illuminate\Support\Str;
 use JustBetter\Http3EarlyHints\Middleware\AddHttp3EarlyHints;
 
@@ -16,13 +20,13 @@ class AddHttp3EarlyHintsTest extends TestCase
         parent::setUp();
     }
 
-    public function getNewRequest()
+    public function getNewRequest(): Request
     {
         return new Request(server: $_SERVER);
     }
 
     /** @test */
-    public function it_will_not_exceed_size_limit()
+    public function it_will_not_exceed_size_limit(): void
     {
         $request = $this->getNewRequest();
 
@@ -35,7 +39,7 @@ class AddHttp3EarlyHintsTest extends TestCase
     }
 
     /** @test */
-    public function it_will_not_add_excluded_asset()
+    public function it_will_not_add_excluded_asset(): void
     {
         $request = $this->getNewRequest();
         config(['http3earlyhints' => ['exclude_keywords' => ['thing']]]);
@@ -47,7 +51,7 @@ class AddHttp3EarlyHintsTest extends TestCase
     }
 
     /** @test */
-    public function it_will_not_modify_a_response_with_no_server_push_assets()
+    public function it_will_not_modify_a_response_with_no_server_push_assets(): void
     {
         $request = $this->getNewRequest();
 
@@ -57,7 +61,7 @@ class AddHttp3EarlyHintsTest extends TestCase
     }
 
     /** @test */
-    public function it_will_return_a_css_link_header_for_css()
+    public function it_will_return_a_css_link_header_for_css(): void
     {
         $request = $this->getNewRequest();
 
@@ -68,7 +72,7 @@ class AddHttp3EarlyHintsTest extends TestCase
     }
 
     /** @test */
-    public function it_will_return_a_js_link_header_for_js()
+    public function it_will_return_a_js_link_header_for_js(): void
     {
         $request = $this->getNewRequest();
 
@@ -79,7 +83,7 @@ class AddHttp3EarlyHintsTest extends TestCase
     }
 
     /** @test */
-    public function it_will_return_a_js_link_header_with_crossorigin_for_js_module()
+    public function it_will_return_a_js_link_header_with_crossorigin_for_js_module(): void
     {
         $request = $this->getNewRequest();
 
@@ -91,7 +95,7 @@ class AddHttp3EarlyHintsTest extends TestCase
     }
 
     /** @test */
-    public function it_will_return_a_js_link_header_with_use_credentials_crossorigin_for_js_module()
+    public function it_will_return_a_js_link_header_with_use_credentials_crossorigin_for_js_module(): void
     {
         $request = $this->getNewRequest();
 
@@ -103,7 +107,7 @@ class AddHttp3EarlyHintsTest extends TestCase
     }
 
     /** @test */
-    public function it_will_return_an_image_link_header_for_images()
+    public function it_will_return_an_image_link_header_for_images(): void
     {
         $request = $this->getNewRequest();
 
@@ -115,7 +119,7 @@ class AddHttp3EarlyHintsTest extends TestCase
     }
 
     /** @test */
-    public function it_will_return_an_image_link_header_for_svg_objects()
+    public function it_will_return_an_image_link_header_for_svg_objects(): void
     {
         $request = $this->getNewRequest();
 
@@ -127,7 +131,7 @@ class AddHttp3EarlyHintsTest extends TestCase
     }
 
     /** @test */
-    public function it_will_return_a_fetch_link_header_for_fetch()
+    public function it_will_return_a_fetch_link_header_for_fetch(): void
     {
         $request = $this->getNewRequest();
 
@@ -139,7 +143,7 @@ class AddHttp3EarlyHintsTest extends TestCase
     }
 
     /** @test */
-    public function it_returns_well_formatted_link_headers()
+    public function it_returns_well_formatted_link_headers(): void
     {
         $request = $this->getNewRequest();
 
@@ -149,7 +153,7 @@ class AddHttp3EarlyHintsTest extends TestCase
     }
 
     /** @test */
-    public function it_will_return_correct_push_headers_for_multiple_assets()
+    public function it_will_return_correct_push_headers_for_multiple_assets(): void
     {
         $request = $this->getNewRequest();
 
@@ -162,7 +166,7 @@ class AddHttp3EarlyHintsTest extends TestCase
     }
 
     /** @test */
-    public function it_will_not_return_a_push_header_for_inline_js()
+    public function it_will_not_return_a_push_header_for_inline_js(): void
     {
         $request = $this->getNewRequest();
 
@@ -172,7 +176,7 @@ class AddHttp3EarlyHintsTest extends TestCase
     }
 
     /** @test */
-    public function it_will_not_return_a_push_header_for_icons()
+    public function it_will_not_return_a_push_header_for_icons(): void
     {
         $request = $this->getNewRequest();
 
@@ -182,7 +186,7 @@ class AddHttp3EarlyHintsTest extends TestCase
     }
 
     /** @test */
-    public function it_will_append_to_header_if_already_present()
+    public function it_will_append_to_header_if_already_present(): void
     {
         $request = $this->getNewRequest();
 
@@ -200,28 +204,18 @@ class AddHttp3EarlyHintsTest extends TestCase
         $this->assertStringEndsWith('as="style"', $response->headers->get('link'));
     }
 
-    /**
-     * @param  string  $pageName
-     * @return \Closure
-     */
-    protected function getNext($pageName)
+    protected function getNext(string $pageName): Closure
     {
-        $html = $this->getHtml($pageName);
-
-        $response = (new \Illuminate\Http\Response($html));
-
-        return function ($request) use ($response) {
-            return $response;
-        };
+        return static fn ($request) => new Response(
+            content: $this->getHtml($pageName),
+        );
     }
 
-    /**
-     * @param  string  $pageName
-     * @return string
-     */
-    protected function getHtml($pageName)
+    protected function getHtml(string $pageName): string
     {
-        return file_get_contents(__DIR__."/fixtures/{$pageName}.html");
+        return file_get_contents(
+            filename: __DIR__."/fixtures/{$pageName}.html",
+        );
     }
 
     private function isServerPushResponse($response)

--- a/tests/AddHttp3EarlyHintsTest.php
+++ b/tests/AddHttp3EarlyHintsTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace JustBetter\Http3EarlyHints\Tests;
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace JustBetter\Http3EarlyHints\Tests;
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace JustBetter\Http3EarlyHints\Tests;
 


### PR DESCRIPTION
- Added `declare(strict-types=1);` to ensure that every type is strictly followed.
- Added missing return types so callables will know what will be returned
- Reformated code so its more readable with `&&` and `||` signs.
- Re-arranged the simplicity of the `||` checks.
- Removed `intval(...)` and did `(int)` casting. Which performs up to 6 times faster.
- Returned void for addLinkHeaders since its private and the return is never used.
- For LinkHeaders.php I've removed the null-operator `?`. This could cause an error whenever the `null` was passed. Now it can't throw an error anymore due to the foreach which was a few lines later.
- Renamed variable instead of rewriting the variable (bad coding behavior)
- Tested everything in the test folder to assure everything complies.